### PR TITLE
Upgrade to Alpine 3.11 and awscli 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM alpine:3.6
+FROM alpine:3.11
 
+# aws-cfn-bootstrap scripts require python 2 still :-(
+# See https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/151
 RUN apk --no-cache --update add curl ca-certificates groff less openssl python py-pip && \
   pip install --no-cache-dir --upgrade pip && \
-  pip install --no-cache-dir awscli~=1.14 https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+  pip install --no-cache-dir awscli~=1.18 https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Docker Automated build](https://img.shields.io/docker/build/countingup/awscli.svg)](https://hub.docker.com/r/countingup/awscli/builds/)
 
-Utility container built on Alpine 3.6 for interaction with AWS services.
+Utility container built on Alpine 3.11 for interaction with AWS services.
 
-Includes recent AWS client tools (awscli version~=1.14), to interact with the AWS platform via
-command line, AWS CloudFormation helper scripts, and curl with SSL support (so openssl plus
+Includes recent AWS client tools (awscli version~=1.18), to interact with the AWS platform via
+command line, (AWS CloudFormation helper scripts)[https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-helper-scripts-reference.html], and curl with SSL support (so openssl plus
  ca-certificates) to allow scripting HTTP/HTTPS calls (e.g. to query metadata).
 
 ## Build locally


### PR DESCRIPTION
N.B. this is a public repo.

Update dependencies for this image. aws-cfn-boostrap requires Python 2 still, so can't upgrade to Python 3, see #1 